### PR TITLE
Fix username reference in user command

### DIFF
--- a/bots/discord/commands/user.js
+++ b/bots/discord/commands/user.js
@@ -42,7 +42,13 @@ module.exports = function(m) {
      * Vérifier si l'utilisateur est bien sur le serveur
      */
     const member = m.message.guild.member(user);
-    if (!member) return embed(m.message, 'Not possible', 15158332, '@' + username + ' is not on your server. Or wasn\'t found.', m.user);
+    if (!member) return embed(
+        m.message,
+        'Not possible',
+        15158332,
+        '@' + user.username + " is not on your server. Or wasn't found.",
+        m.user
+    );
 
     /**
      * Création des constantes, informations sur l'utilisateur à mettre admin


### PR DESCRIPTION
## Summary
- fix undefined `username` reference if mentioned user isn't on server

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847857e6bc4832297e539ae4354d0aa